### PR TITLE
Volume cookie for MVP sounds

### DIFF
--- a/addons/sourcemod/scripting/store_item_mvpsound.sp
+++ b/addons/sourcemod/scripting/store_item_mvpsound.sp
@@ -32,6 +32,7 @@
 
 #include <sourcemod>
 #include <sdktools>
+#include <clientprefs>
 
 #include <store>
 #include <zephstocks>

--- a/addons/sourcemod/scripting/store_item_mvpsound.sp
+++ b/addons/sourcemod/scripting/store_item_mvpsound.sp
@@ -219,7 +219,10 @@ public void Store_OnPreviewItem(int client, char[] type, int index)
 	if (!StrEqual(type, "mvp_sound"))
 		return;
 
-	EmitSoundToClient(client, g_sSound[index], client, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_NOFLAGS, (g_fVolume[index] * g_fPlayerVolume[client]) / 2);
+	if (RoundToNearest(g_fPlayerVolume[client] * 100) != 0) // Rounded because computers struggle with floats and precise values
+		EmitSoundToClient(client, g_sSound[index], client, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_NOFLAGS, g_fVolume[index] * g_fPlayerVolume[client]);
+	else
+		EmitSoundToClient(client, g_sSound[index], client, SNDCHAN_AUTO, SNDLEVEL_NORMAL, SND_NOFLAGS, g_fVolume[index] * VOLUME_COOKIE_STEP); // Set to the step right above 0%
 
 	CPrintToChat(client, "%s%t", g_sChatPrefix, "Play Preview", client);
 }

--- a/addons/sourcemod/scripting/store_item_mvpsound.sp
+++ b/addons/sourcemod/scripting/store_item_mvpsound.sp
@@ -90,6 +90,8 @@ public void OnClientCookiesCached(int client)
 {
 	char sValue[8];
 	g_hHideCookie.Get(client, sValue, sizeof(sValue));
+	if (sValue[0] == '\0') // If the string is empty, it means that the user has not changed their volume. Don't do anything.
+		return;
 	
 	g_fPlayerVolume[client] = StringToFloat(sValue);
 }
@@ -98,7 +100,7 @@ public void PrefMenu(int client, CookieMenuAction actions, any info, char[] buff
 {
 	if (actions == CookieMenuAction_DisplayOption)
 	{
-		FormatEx(buffer, maxlen, "MVP Volume: %i", RoundToCeil(g_fPlayerVolume[client] * 100)); // Rounding because we never know
+		FormatEx(buffer, maxlen, "MVP Volume: %i%%", RoundToNearest(g_fPlayerVolume[client] * 100)); // Rounding because we never know
 	}
 	else if (actions == CookieMenuAction_SelectOption)
 	{
@@ -120,7 +122,7 @@ void CMD_Volume(int client)
 	g_hHideCookie.Set(client, sCookieValue);
 	
 	char buffer[20];
-	FormatEx(buffer, sizeof(buffer), "%i%%%%", RoundToCeil(g_fPlayerVolume[client] * 100));
+	FormatEx(buffer, sizeof(buffer), "%i%%", RoundToNearest(g_fPlayerVolume[client] * 100));
 	CPrintToChat(client, "%s%t", g_sChatPrefix, "Volume set", "MVP", buffer);
 }
 
@@ -184,6 +186,7 @@ public int MVPSounds_Remove(int client, int itemid)
 public void OnClientDisconnect(int client)
 {
 	g_iEquipt[client] = -1;
+	g_fPlayerVolume[client] = 1.0;
 }
 
 
@@ -206,7 +209,8 @@ public void Event_RoundMVP(Event event, char[] name, bool dontBroadcast)
 
 		ClientCommand(i, "playgamesound Music.StopAllMusic");
 
-		EmitSoundToClient(i, g_sSound[g_iEquipt[client]], SOUND_FROM_PLAYER, SNDCHAN_STATIC, SNDLEVEL_NONE, _, g_fVolume[g_iEquipt[client]] * g_fPlayerVolume[i]);
+		if (RoundToNearest(g_fPlayerVolume[i] * 100) != 0) // Rounded because computers struggle with floats and precise values
+			EmitSoundToClient(i, g_sSound[g_iEquipt[client]], SOUND_FROM_PLAYER, SNDCHAN_STATIC, SNDLEVEL_NONE, _, g_fVolume[g_iEquipt[client]] * g_fPlayerVolume[i]);
 	}
 }
 

--- a/addons/sourcemod/translations/store.phrases.txt
+++ b/addons/sourcemod/translations/store.phrases.txt
@@ -1,5 +1,12 @@
 ﻿"Phrases"
-{	
+{
+	"Volume set"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"{green}{1} {default}volume set to {purple}{2}"
+		"fr"		"Volume {green}{1} {default}réglé à {purple}{2}"
+	}
+	
 	"CP Disabled Color"
 	{
 		"en" "Custom tag color disabled."


### PR DESCRIPTION
This PR adds a volume cookie for MVP sounds, which can be set using the `sm_settings` command.

This is a really requested feature from my players.

Just click the menu item and the MVPs volume will be 20% lower compared to original.

It works with steps of 20% by default (can be configured using the constant defined at the top of the plugin).
If the percentage is lower than 0%, it will be set back to 100%.

The volume setting is personal and will not affect other clients.

**Feel free to edit the patch-1 branch to modify things that you want to change, or just request changes.**

---

**Noteworthy changes:**
- Improved the plugin's description
- Added the repo URL
- Added a new phrase "Volume set", which is already translated in english and french

---
**PR Status:**

✅ Compiles fine
✅ Tested in game and works fine