### PR TITLE
Preview for Scoreboard tag, Colored Smoke, some edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ P/S: Note. Store mainly supported for csgo, any others game (css, l4d2) may have
 - Say sound
 - Re-add valve's weapon skins and knives (warning: this may cause your server get ban. Please use at your own risk).
 	(Please uncomment //#define WEAPONS_KNIVES to enable this module)
-- Name tag, name and message color.
+- Name tag, scoreboard tag, name and message color.
+- Colored Smoke ported from SHOP. ([youtube](https://www.youtube.com/watch?v=cTyMnAmgixI))
+	(You can change smoke color or change smoke particle's material to custom material.)
 - more will be supported
 # Modules has no preview support:
 - PaintBall Effects (by shanapu)
 - Bullet Spark (by shanapu)
 - Grenade trail (by zephyrus)
 - Laser sight (by zephyrus)
-- Colored Smoke ported from SHOP. ([youtube](https://www.youtube.com/watch?v=cTyMnAmgixI))
-	(You can change smoke color or change smoke particle's material to custom material. Current no preview support. Preview will support in 1.1 version)
 # New feature added:
 - Added "preview" key value enable preview system
 - Added "steam" key value which support for exclusive skin (special thanks Shanabu)

--- a/addons/sourcemod/configs/store/config_example/store_item_colored_smoke.txt
+++ b/addons/sourcemod/configs/store/config_example/store_item_colored_smoke.txt
@@ -18,6 +18,7 @@
 		"price" "100"
 		"material"		"particle/particle_smokegrenade1.vmt"	// string. The particle materials use for smoke. This is default value (You can change to custom one).
 		"type" "ColoredSmoke"
+		"preview"		"1"
 	}
 	
 	"Ny Rainbow"
@@ -38,5 +39,6 @@
 		"price" "100"
 		"material"		"aif/sprites/nydancerainbow.vmt"	// string. The particle materials use for smoke.
 		"type" "ColoredSmoke"
+		"preview"		"1"
 	}
 }

--- a/addons/sourcemod/configs/store/config_example/store_item_cpsupport.txt
+++ b/addons/sourcemod/configs/store/config_example/store_item_cpsupport.txt
@@ -59,6 +59,27 @@
 			"type" "msgcolor"
 			"preview" "1"
 		}
+		"Rainbow"
+		{
+			"color" "rainbow"
+			"unique_id" "uid_msgcolor_rainbow"
+			"Plans"
+			{
+				"7 days"
+				{
+					"price" "3000"
+					"time" "604800"
+				}
+				
+				"30 days"
+				{
+					"price" "18000"
+					"time" "2592000"
+				}
+			}
+			"type" "msgcolor"
+			"preview" "1"
+		}
 	}
    	 "Scoreboard Tag"
   	  {

--- a/addons/sourcemod/configs/store/config_example/store_item_cpsupport.txt
+++ b/addons/sourcemod/configs/store/config_example/store_item_cpsupport.txt
@@ -34,6 +34,27 @@
 			"type" "namecolor"
 			"preview" "1"
 		}
+		"Rainbow"
+		{
+			"color" "rainbow"
+			"unique_id" "uid_namecolor_rainbow"
+			"Plans"
+			{
+				"7 days"
+				{
+					"price" "2000"
+					"time" "604800"
+				}
+				
+				"30 days"
+				{
+					"price" "15000"
+					"time" "2592000"
+				}
+			}
+			"type" "namecolor"
+			"preview" "1"
+		}
 	}
 				
 	"Message Color"

--- a/addons/sourcemod/configs/store/config_example/store_item_cpsupport.txt
+++ b/addons/sourcemod/configs/store/config_example/store_item_cpsupport.txt
@@ -68,6 +68,7 @@
 			"price" "100"
 			"type" "scoreboardtag"
 			"unique_id" "uid_scoreboardtag_j1bros"
+			"preview" "1"
        		 }
 	}
 }

--- a/addons/sourcemod/scripting/store/store_misc_toplists.sp
+++ b/addons/sourcemod/scripting/store/store_misc_toplists.sp
@@ -71,7 +71,7 @@ void Menu_TopLists(int client)
 	Menu menu = new Menu(Handler_TopLists);
 
 	char sBuffer[128];
-	int i_Credits = g_eClients[client][iCredits]; // Get credits
+	int i_Credits = Store_GetClientCredits(client); // Get credits
 	Format(sBuffer, sizeof(sBuffer), "%t - %s\n%t", "Title Store", "toplists", "Title Credits", i_Credits);
 	menu.SetTitle(sBuffer);
 
@@ -93,6 +93,14 @@ public int Handler_TopLists(Menu menu, MenuAction action, int client, int param2
 {
 	if (action == MenuAction_Select)
 	{
+		if(param2 == 0)
+			g_iList[client] = TL_CREDITS;
+		else if(param2 == 1)
+			g_iList[client] = TL_ITEMS;
+		else if(param2 == 2)
+			g_iList[client] = TL_INV;
+		else if(param2 == 3)
+			g_iList[client] = TL_INV_CREDITS;
 		Panel_Credits(client, param2);
 	}
 	else if (action == MenuAction_Cancel)
@@ -288,10 +296,10 @@ void Panel_Credits(int client, int type)
 {
 	Panel panel = new Panel();
 
-	char sName[64];
-	char sBuffer[64];
+	char sName[256];
+	char sBuffer[256], sBuffer2[256];
 
-	int i_Credits = g_eClients[client][iCredits]; // Get credits
+	int i_Credits = Store_GetClientCredits(client); // Get credits
 
 	//Choose right Title for toplist
 	switch(type)
@@ -322,11 +330,14 @@ void Panel_Credits(int client, int type)
 			case TL_INV, TL_INV_CREDITS:
 			{
 				int items = pack.ReadCell();
-				Format(sBuffer, sizeof(sBuffer), "    %i. %s:   %i %s (%i items)", i + 1, sName, credits, g_sCreditsName, items);
+				Format(sBuffer, sizeof(sBuffer), "%t", "items");
+				Format(sBuffer, sizeof(sBuffer), "%t", "inv and inv credits", i + 1, sName, credits, g_sCreditsName, items, sBuffer);
 			}
 			case TL_CREDITS, TL_ITEMS:
 			{
-				Format(sBuffer, sizeof(sBuffer), "    %i. %s:   %i %s", i + 1, sName, credits, type == TL_CREDITS ? g_sCreditsName : "Items");
+				Format(sBuffer, sizeof(sBuffer), "%t", "items");
+				Format(sBuffer2, sizeof(sBuffer2), "%t", "creditstoplist", g_sCreditsName);
+				Format(sBuffer, sizeof(sBuffer), "    %i. %s:   %i %s", i + 1, sName, credits, type == TL_CREDITS ? sBuffer2 : sBuffer);
 			}
 		}
 		panel.DrawText(sBuffer);
@@ -347,7 +358,7 @@ void Panel_Credits(int client, int type)
 	else
 	{
 		SecToTime(GetTime() - g_iUpdateTime, sBuffer, sizeof(sBuffer));
-		Format(sBuffer, sizeof(sBuffer), "    %s %s ago", "last update", sBuffer);
+		Format(sBuffer, sizeof(sBuffer), "%t", "last update", sBuffer);
 		panel.DrawText(sBuffer);
 
 		//When last update older than "mystore_toplist_update_interval"
@@ -428,14 +439,14 @@ int SecToTime(int time, char[] buffer, int size)
 
 	if (iHours >= 1)
 	{
-		Format(buffer, size, "%t", "x hours, x minutes, x seconds", iHours, iMinutes, iSeconds);
+		Format(buffer, size, "%t", "x hours, x minutes, x seconds toplist", iHours, iMinutes, iSeconds);
 	}
 	else if (iMinutes >= 1)
 	{
-		Format(buffer, size, "%t", "x minutes, x seconds", iMinutes, iSeconds);
+		Format(buffer, size, "%t", "x minutes, x seconds toplist", iMinutes, iSeconds);
 	}
 	else
 	{
-		Format(buffer, size, "%t", "x seconds", iSeconds);
+		Format(buffer, size, "%t", "x seconds toplist", iSeconds);
 	}
 }

--- a/addons/sourcemod/scripting/store_item_cpsupport.sp
+++ b/addons/sourcemod/scripting/store_item_cpsupport.sp
@@ -593,7 +593,14 @@ public void Store_OnPreviewItem(int client, char[] type, int index)
 	}
 	else if(StrEqual(type, "namecolor"))
 	{
-		Format(sBuffer, sizeof(sBuffer), "%s%s :{default}", g_sNameColors[index], clientname);
+		if(StrEqual(g_sNameColors[index], "rainbow"))
+		{
+			String_Rainbow(clientname, sBuffer, sizeof(sBuffer));
+			Format(sBuffer, sizeof(sBuffer), "%s :{default}", sBuffer);
+		}
+		else
+			Format(sBuffer, sizeof(sBuffer), "%s%s :{default}", g_sNameColors[index], clientname);
+			
 		Format(PreviewBuffer, sizeof(PreviewBuffer), "%t", "This is the preview text");
 		CPrintToChat(client, "%t", "CP Preview", " ", sBuffer, PreviewBuffer);
 	}

--- a/addons/sourcemod/scripting/store_item_cpsupport.sp
+++ b/addons/sourcemod/scripting/store_item_cpsupport.sp
@@ -1,5 +1,3 @@
-
-
 #include <sourcemod>
 #include <sdktools>
 #include <colorvariables>
@@ -48,6 +46,7 @@ char g_szColors[MAXPLAYERS + 1][16];
 char g_szAuth[MAXPLAYERS + 1][32];
 #if defined csgo_css
 char g_sTempClanTag[MAXPLAYERS + 1][32];
+char g_sPreviewClantag[MAXPLAYERS + 1][32];
 #endif
 
 public Plugin myinfo = 
@@ -55,7 +54,7 @@ public Plugin myinfo =
 	name = "Store - Chat Processor item module with Scoreboard Tag",
 	author = "nuclear silo, Mesharsky, AiDN™", 
 	description = "Chat Processor item module by nuclear silo, the Scoreboard Tag for Zephyrus's by Mesharksy, for nuclear silo's edited store by AiDN™",
-	version = "2.2", 
+	version = "2.3", 
 	url = ""
 };
 
@@ -72,7 +71,7 @@ public void OnPluginStart()
 	PrintToServer("CS:GO, CSS detected as a game engine. The scoreboard tag module will be enabled.");
 	
 	#else 
-	PrintToServer("Can not detecte CS:GO, CSS as a game engine. The scoreboard tag module will be disabled.");
+	PrintToServer("Can not detected CS:GO, CSS as a game engine. The scoreboard tag module will be disabled.");
 	#endif
 	
 	HookEvent("player_team", PlayerTeam_Callback);
@@ -325,7 +324,7 @@ public int MenuHandler_Shop(Menu menu, MenuAction action, int client, int item)
 			kvtShop.GetString("color", sItem, sizeof(sItem));
 
 			strcopy(g_szColors[client], sizeof(g_szColors), sItem);
-			CPrintToChat(client, "%s You changed your color to: %s%s.", g_sChatPrefix, sItem, name);
+			CPrintToChat(client, "%s%t%s%s.", g_sChatPrefix, "CP Changed color", sItem, name);
 			SQL_UpdatePerk(client, sItem);
 		}
 	}
@@ -563,6 +562,18 @@ public void Store_OnPreviewItem(int client, char[] type, int index)
 		Format(sBuffer, sizeof(sBuffer), " %s%s", g_sMessageColors[index], PreviewBuffer);
 		CPrintToChat(client, "%t", "CP Preview", " ", Buffer, sBuffer);
 	}
+	#if defined csgo_css
+	else if(StrEqual(type, "scoreboardtag"))
+	{
+		CS_GetClientClanTag(client, g_sPreviewClantag[client], 32);
+
+		CS_SetClientClanTag(client, g_sScoreboardTags[index]);
+
+		CreateTimer(15.0, Clantag, client);
+
+		CPrintToChat(client, "%s%t", g_sChatPrefix, "CP Scoreboard Preview");
+	}
+	#endif
 	else return;
 }
 
@@ -599,3 +610,10 @@ public void Store_SetClientClanTag(int client)
 	CS_SetClientClanTag(client, sBuffer);
 	#endif
 }
+
+#if defined csgo_css
+public Action Clantag(Handle timer, int client)
+{
+	CS_SetClientClanTag(client, g_sPreviewClantag[client]);
+}
+#endif

--- a/addons/sourcemod/scripting/store_item_cpsupport.sp
+++ b/addons/sourcemod/scripting/store_item_cpsupport.sp
@@ -17,6 +17,7 @@
 
 #pragma semicolon 1
 #pragma newdecls required
+#pragma tabsize 0
 
 char g_sChatPrefix[128];
 
@@ -53,7 +54,7 @@ public Plugin myinfo =
 	name = "Store - Chat Processor item module with Scoreboard Tag",
 	author = "nuclear silo, Mesharsky, AiDN™", 
 	description = "Chat Processor item module by nuclear silo, the Scoreboard Tag for Zephyrus's by Mesharksy, for nuclear silo's edited store by AiDN™",
-	version = "2.3", 
+	version = "2.4", 
 	url = ""
 };
 
@@ -439,28 +440,57 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 	if (iEquippedNameColor >= 0)
 	{
 		int m_iData = Store_GetDataIndex(iEquippedNameColor);
-		strcopy(sNameColor, sizeof(sNameColor), g_sNameColors[m_iData]);
-	}
-	
-	if(!StrEqual(g_szColors[author], "disabled", true))
-	{
-		//if(StrContains(sNameTag, "}", true))
-		if(/*slited != 0 || */sNameTag2[1][0] != '\0')
+		if(StrEqual(g_sNameColors[m_iData], "rainbow"))
 		{
-			//PrintToChat(author, "have }");
-			Format(sName, sizeof(sName), "%s%s{teamcolor}%s%s", g_szColors[author], sNameTag2[1], sNameColor, name);
+            String_Rainbow(name, sNameColor, sizeof(sNameColor));
+            
+            if(!StrEqual(g_szColors[author], "disabled", true))
+			{
+				//if(StrContains(sNameTag, "}", true))
+				if(/*slited != 0 || */sNameTag2[1][0] != '\0')
+				{
+					//PrintToChat(author, "have }");
+					Format(sName, sizeof(sName), "%s%s%s", g_szColors[author], sNameTag2[1], sNameColor);
+				}
+				else 
+				{
+					//PrintToChat(author, "no have }");
+					Format(sName, sizeof(sName), "%s%s%s", g_szColors[author], sNameTag, sNameColor);
+				}
+			}
+			else Format(sName, sizeof(sName), "%s%s", sNameTag, sNameColor);
+			
+			//ReplaceColors(sName, sizeof(sName), author);
+		
+			strcopy(name, MAXLENGTH_NAME, sName);
 		}
-		else 
+		else
 		{
-			//PrintToChat(author, "no have }");
-			Format(sName, sizeof(sName), "%s%s{teamcolor}%s%s", g_szColors[author], sNameTag, sNameColor, name);
+			strcopy(sNameColor, sizeof(sNameColor), g_sNameColors[m_iData]);
+			if(!StrEqual(g_szColors[author], "disabled", true))
+			{
+				//if(StrContains(sNameTag, "}", true))
+				if(/*slited != 0 || */sNameTag2[1][0] != '\0')
+				{
+					//PrintToChat(author, "have }");
+					Format(sName, sizeof(sName), "%s%s{teamcolor}%s%s", g_szColors[author], sNameTag2[1], sNameColor, name);
+				}
+				else 
+				{
+					//PrintToChat(author, "no have }");
+					Format(sName, sizeof(sName), "%s%s{teamcolor}%s%s", g_szColors[author], sNameTag, sNameColor, name);
+				}
+			}
+			else Format(sName, sizeof(sName), "%s{teamcolor}%s%s", sNameTag, sNameColor, name);
+			
+			//ReplaceColors(sName, sizeof(sName), author);
+		
+			strcopy(name, MAXLENGTH_NAME, sName);		
 		}
+		
+		/*int m_iData = Store_GetDataIndex(iEquippedNameColor);
+		strcopy(sNameColor, sizeof(sNameColor), g_sNameColors[m_iData]);*/
 	}
-	else Format(sName, sizeof(sName), "%s{teamcolor}%s%s", sNameTag, sNameColor, name);
-	
-	//ReplaceColors(sName, sizeof(sName), author);
-
-	strcopy(name, MAXLENGTH_NAME, sName);
 
 	if (iEquippedMsgColor >= 0)
     {

--- a/addons/sourcemod/translations/store.phrases.txt
+++ b/addons/sourcemod/translations/store.phrases.txt
@@ -87,6 +87,16 @@
 		"fr"		"Volume {green}{1} {default}réglé à {purple}{2}"
 	}
 	
+	"CP Changed color"
+	{
+		"en"		"You changed your color to: "
+	}
+	
+	"CP Scoreboard Preview"
+	{
+		"en"		"Showing preview scoreboard tag, please press TAB button."
+	}
+	
 	"CP Disabled Color"
 	{
 		"en" "Custom tag color disabled."
@@ -889,6 +899,12 @@
 	{
 		"en"		"Playing preview sound for you."
 		"chi"		"为你播放预览声音。"
+	}
+
+	"Spawn Preview - Colored smoke"
+	{
+		"#format"	"{1:.0f}"
+		"en"		"Spawned a preview. Preview will disappear in {1} seconds."
 	}
 
 	"Parachute Reloaded"
@@ -2237,7 +2253,7 @@
 
 	"inv and inv credits"
 	{
-		"#format"	"{1:i},{2:s},{3:i},{4:s},{5:i},{6:s},"
+		"#format"	"{1:i},{2:s},{3:i},{4:s},{5:i},{6:s}"
 		"en"		"    {1}. {2}:   {3} {4} ({5} {6})"
 	}
 	

--- a/addons/sourcemod/translations/store.phrases.txt
+++ b/addons/sourcemod/translations/store.phrases.txt
@@ -87,6 +87,16 @@
 		"fr"		"Volume {green}{1} {default}réglé à {purple}{2}"
 	}
 	
+	"CP Chat Tag Color Option"
+	{
+		"en"	"Chat tag color option"
+	}
+
+	"CP Disable color - Menu"
+	{
+		"en"	"Disable color"
+	}
+
 	"CP Changed color"
 	{
 		"en"		"You changed your color to: "

--- a/addons/sourcemod/translations/store.phrases.txt
+++ b/addons/sourcemod/translations/store.phrases.txt
@@ -92,7 +92,7 @@
 		"en"	"Chat tag color option"
 	}
 
-	"CP Disable color - Menu"
+	"CP Disable Color - Menu"
 	{
 		"en"	"Disable color"
 	}


### PR DESCRIPTION
Added for the README.md the scoreboard tag and colored smoke preview
Added 3 new translation (CP Changed color, CP Scoreboard Preview and Spawn Preview - Colored smoke), one "," removed from "inv and inv credits"
Added the "preview" "1" to the configs (colored_smoke and cpsupport)
Edited store/store_misc_toplists.sp for the translations and for good working (example: Handler_TopLists)
Added preview for Colored Smoke and for Scoreboard tag,
Colored Smoke remove after the lifetime (from the config) and the smoke is stops after 5 seconds
Scoreboard tag remove after 15 seconds and set the previous clantag from the client

Edited /06.15/
- Removed g_sPreviewClantag char, now using g_sTempClanTag
- Added an "a" letter to LogError
- Added translations to the menu (CP Chat Tag Color Option and CP Disable Color - Menu)
- Removed 2 space from CP Disabled Color
- Added the rainbow message color (check configs how work)
- MAXLENGTH_BUFFER edited to MAXLENGTH_MESSAGE (to avoid the exception reports from chat_processor)

Edited /06.16/
- Added the rainbow name color (check configs how work)

Informations:
✅ - 0 warning/error with SM 1.10 compile
✅ - Tested in-game, 0 error/bug