### PR TITLE
Fixed an error in Trails_PlayerDeath

### DIFF
--- a/addons/sourcemod/scripting/store_item_trails.sp
+++ b/addons/sourcemod/scripting/store_item_trails.sp
@@ -229,7 +229,7 @@ public Action Trails_PlayerSpawn(Handle event, const char[] name, bool dontBroad
 public Action Trails_PlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(GetEventInt(event, "userid"));
-	if(!IsPlayerAlive(client))
+	if(client && !IsPlayerAlive(client))
 		for(int i=0;i<STORE_MAX_SLOTS;++i)
 			RemoveTrail(client, i);
 	return Plugin_Continue;


### PR DESCRIPTION
Fixed a reported error (in #65) in Trails_PlayerDeath.

A really simple fix.

The error code:
```
[SM] Blaming: store_item_trails.smx
[SM] Call stack trace:
[SM]   [0] IsPlayerAlive
[SM]   [1] Line 254, store_item_trails.sp::Trails_PlayerDeath
```

Didn't know the userid could be invalid, but it seems like it. This fix simply verifies that the userid belongs to a client before executing further functions.

Due to the line count being off, I suspect the person that reported this bug wasn't using an updated version (but it could be a line count bug).

Either way, this bug wasn't fixed in the more recent versions.