### PR TITLE
Lootbox: fix expiration time when using "store_lootbox_item_sellable 1"

### DIFF
--- a/addons/sourcemod/scripting/store_misc_lootbox.sp
+++ b/addons/sourcemod/scripting/store_misc_lootbox.sp
@@ -556,9 +556,9 @@ public Action Timer_Open(Handle timer, int client)
 			{
 				if(item.iPlans!=0)
 				{
-					Store_GiveItem(client, itemid, _, GetTime() + g_iTime[g_iClientBox[client]], 2);
+					Store_GiveItem(client, itemid, _, GetTime() + time, 2);
 				}
-				else Store_GiveItem(client, itemid, _, GetTime() + g_iTime[g_iClientBox[client]], item.iPrice);
+				else Store_GiveItem(client, itemid, _, GetTime() + time, item.iPrice);
 			}
 			else Store_GiveItem(client, itemid, _, GetTime() + time, 1);
 		}
@@ -568,9 +568,9 @@ public Action Timer_Open(Handle timer, int client)
 			{
 				if(item.iPlans!=0)
 				{
-					Store_GiveItem(client, itemid, _, GetTime() + g_iTime[g_iClientBox[client]], 2);
+					Store_GiveItem(client, itemid, _, _, 2);
 				}
-				else Store_GiveItem(client, itemid, _, GetTime() + g_iTime[g_iClientBox[client]], item.iPrice);
+				else Store_GiveItem(client, itemid, _, _, item.iPrice);
 			}
 			else Store_GiveItem(client, itemid, _, _, 1);
 		}


### PR DESCRIPTION
Fixes #80 

This fixes issues with the expiration time not being the good one when the `store_lootbox_item_sellable` cvar is enabled

The issue was introduced by this commit: https://github.com/nuclearsilo583/zephyrus-store-preview-new-syntax/commit/908837df96fc88eae13772507a3ce773306995a4

✅ Compiles fine
❌ Not tested in-game