### PR TITLE
Fixed a crash related to model precaching

### DIFF
--- a/addons/sourcemod/scripting/store_item_grenskins.sp
+++ b/addons/sourcemod/scripting/store_item_grenskins.sp
@@ -99,8 +99,8 @@ public bool GrenadeSkins_Config(Handle &kv,int itemid)
 		return false;
 	
 	// Precache to prevent crashes on the initial loading (OnMapStart would be called on the next map because this function call is delayed by a query)
-	PrecacheModel2(g_eGrenadeSkins[i].szModel_Grenade);
-	Downloader_AddFileToDownloadsTable(g_eGrenadeSkins[i].szModel_Grenade);
+	PrecacheModel2(g_eGrenadeSkins[g_iGrenadeSkins].szModel_Grenade);
+	Downloader_AddFileToDownloadsTable(g_eGrenadeSkins[g_iGrenadeSkins].szModel_Grenade);
 	
 	++g_iGrenadeSkins;
 	return true;

--- a/addons/sourcemod/scripting/store_item_grenskins.sp
+++ b/addons/sourcemod/scripting/store_item_grenskins.sp
@@ -40,8 +40,8 @@ public Plugin myinfo =
 	name = "Store Grenade Skin",
 	author = "zephyrus, nuclear silo",
 	description = "change grenade model",
-	version = "1.3",
-	url = ""
+	version = "1.4",
+	url = "github.com/nuclearsilo583/zephyrus-store-preview-new-syntax"
 }
 
 public void OnPluginStart()
@@ -97,7 +97,11 @@ public bool GrenadeSkins_Config(Handle &kv,int itemid)
 	
 	if(!(FileExists(g_eGrenadeSkins[g_iGrenadeSkins].szModel_Grenade, true)))
 		return false;
-		
+	
+	// Precache to prevent crashes on the initial loading (OnMapStart would be called on the next map because this function call is delayed by a query)
+	PrecacheModel2(g_eGrenadeSkins[i].szModel_Grenade);
+	Downloader_AddFileToDownloadsTable(g_eGrenadeSkins[i].szModel_Grenade);
+	
 	++g_iGrenadeSkins;
 	return true;
 }


### PR DESCRIPTION
(Also added the repo url)

Precaching should be done on map start, but this config function is called after a database query, which could end AFTER OnMapStart, resulting in models not being precached.

This fixes the issue I got on my server of grenade skins not being precached on the first map after server launch, and ensures the plugin won't crash the server if it is loaded late.

Did not add my author name since the fix was very basic.

✅ Compiles fine
❌ Not tested in game