### PR TITLE
Made CheckSteamAuth ignore the steamid2 universe

### DIFF
--- a/addons/sourcemod/scripting/store.sp
+++ b/addons/sourcemod/scripting/store.sp
@@ -5,7 +5,7 @@
 #define PLUGIN_NAME "Store - The Resurrection with preview system"
 #define PLUGIN_AUTHOR "Zephyrus, nuclear silo, AiDN™"
 #define PLUGIN_DESCRIPTION "A completely new Store system with preview rewritten by nuclear silo"
-#define PLUGIN_VERSION "7.0.8"
+#define PLUGIN_VERSION "7.0.9"
 #define PLUGIN_URL ""
 
 #define SERVER_LOCK_IP ""

--- a/addons/sourcemod/scripting/store/store_functions.sp
+++ b/addons/sourcemod/scripting/store/store_functions.sp
@@ -609,7 +609,7 @@ bool CheckSteamAuth(int client, char[] steam)
 	if (!GetClientAuthId(client, AuthId_Steam2, sSteam, 32))
 		return false;
 
-	if (StrContains(steam, sSteam[7]) == -1) // sSteam[7] only keeps the :X:XXXXXXXX part of a SteamID2, so both STEAM_0 and STEAM_1 work
+	if (StrContains(steam, sSteam[8]) == -1) // sSteam[8] only keeps the X:XXXXXXXX part of a SteamID2 (strips 'STEAM_X:'), so both STEAM_0 and STEAM_1 work
 		return false;
 
 	return true;

--- a/addons/sourcemod/scripting/store/store_functions.sp
+++ b/addons/sourcemod/scripting/store/store_functions.sp
@@ -609,7 +609,7 @@ bool CheckSteamAuth(int client, char[] steam)
 	if (!GetClientAuthId(client, AuthId_Steam2, sSteam, 32))
 		return false;
 
-	if (StrContains(steam, sSteam) == -1)
+	if (StrContains(steam, sSteam[7]) == -1) // sSteam[7] only keeps the :X:XXXXXXXX part of a SteamID2, so both STEAM_0 and STEAM_1 work
 		return false;
 
 	return true;

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -4562,7 +4562,7 @@ bool CheckSteamAuth(int client, char[] steam)
 	if (!GetClientAuthId(client, AuthId_Steam2, sSteam, 32))
 		return false;
 
-	if (StrContains(steam, sSteam[7]) == -1) // sSteam[7] only keeps the :X:XXXXXXXX part of a SteamID2, so both STEAM_0 and STEAM_1 work
+	if (StrContains(steam, sSteam[8]) == -1) // sSteam[8] only keeps the X:XXXXXXXX part of a SteamID2 (strips 'STEAM_X:'), so both STEAM_0 and STEAM_1 work
 		return false;
 
 	return true;

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -5,7 +5,7 @@
 #define PLUGIN_NAME "Store - The Resurrection with preview system"
 #define PLUGIN_AUTHOR "Zephyrus, nuclear silo, AiDN™"
 #define PLUGIN_DESCRIPTION "A completely new Store system with preview rewritten by nuclear silo"
-#define PLUGIN_VERSION "7.0.8"
+#define PLUGIN_VERSION "7.0.9"
 #define PLUGIN_URL ""
 
 #define SERVER_LOCK_IP ""
@@ -4562,7 +4562,7 @@ bool CheckSteamAuth(int client, char[] steam)
 	if (!GetClientAuthId(client, AuthId_Steam2, sSteam, 32))
 		return false;
 
-	if (StrContains(steam, sSteam) == -1)
+	if (StrContains(steam, sSteam[7]) == -1) // sSteam[7] only keeps the :X:XXXXXXXX part of a SteamID2, so both STEAM_0 and STEAM_1 work
 		return false;
 
 	return true;


### PR DESCRIPTION
Avoids problems like #109, although I still think that server owners should know about `STEAM_1` and `STEAM_0`.

Just a proposition of a change that could be useful for server owners.
Don't know if it could cause problems with the base code, but shouldn't.
Feel free to decline this PR if you think this change is bad.

❌ Didn't try to compile
❌ Not tested in game