### PR TITLE
Fixed items being removed in a certain scenario #33

### DIFF
--- a/addons/sourcemod/scripting/store/store_functions.sp
+++ b/addons/sourcemod/scripting/store/store_functions.sp
@@ -158,6 +158,8 @@ public void Store_SaveClientInventory(int client)
 			SQL_TVoid(g_hDatabase, m_szQuery);
 		} else if(g_eClientItems[client][i].bSynced && g_eClientItems[client][i].bDeleted)
 		{
+			g_eClientItems[client][i].bSynced = false; // Prevents the function from trying to delete the item again the next time it's called
+			
 			// Might have been synced already but ID wasn't acquired
 			if(g_eClientItems[client][i].iId_Client_Item==-1)
 				Format(STRING(m_szQuery), "DELETE FROM store_items WHERE `player_id`=%d AND `type`=\"%s\" AND `unique_id`=\"%s\"", g_eClients[client].iId_Client, m_szType, m_szUniqueId);

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -3920,6 +3920,8 @@ public void Store_SaveClientInventory(int client)
 			SQL_TVoid(g_hDatabase, m_szQuery);
 		} else if(g_eClientItems[client][i].bSynced && g_eClientItems[client][i].bDeleted)
 		{
+			g_eClientItems[client][i].bSynced = false; // Prevents the function from trying to delete the item again the next time it's called
+			
 			// Might have been synced already but ID wasn't acquired
 			if(g_eClientItems[client][i].iId_Client_Item==-1)
 				Format(STRING(m_szQuery), "DELETE FROM store_items WHERE `player_id`=%d AND `type`=\"%s\" AND `unique_id`=\"%s\"", g_eClients[client].iId_Client, m_szType, m_szUniqueId);


### PR DESCRIPTION
Fixes #33 (original issue with items disappearing): a rather **critical bug**

Items would get removed from a player's inventory if they removed it then got it again in the same map. This bug affected every store item.

Items are deleted through the save inventory function, but they aren't marked as "already deleted":
each call of the save inventory will do a query to delete the store item until it is cleared from memory (map change/player disconnect)

Thus, this data loss bug will **only** happen if no rowid is assigned, which only happens if the item was purchased on the same map:

- Player buys item "test", it gets stored in g_eClientItems under the ID `x`
  - Plugin saves the item in the DB
- Player removes item "test". Item uid "test" is now marked for deletion in memory under the ID `x`
  - Plugin removes the item "test" in the DB because it was marked for deletion in memory under the ID `x`
- Player buys item "test", it gets stored in g_eClientItems under the ID `x+1`
  - Plugin tries to remove item "test" because it was marked for deletion in memory under the ID `x`
  - Plugin saves the item "test" in the DB
- Player disconnects (or the save function gets called again), the inventory saving function will be called and:
  - Plugin removes item "test" because it was marked for deletion in memory under the ID `x`
  - Plugin doesn't insert the item "test" under the ID `x+1` because it is already marked as synced
  - ___The player has now lost their item___

✅ Compiles fine
✅ Tested in game and works