### PR TITLE
Fixed problems with Native_SetClientCredits

### DIFF
--- a/addons/sourcemod/scripting/include/store.inc
+++ b/addons/sourcemod/scripting/include/store.inc
@@ -165,7 +165,6 @@ native int Store_GetClientCredits(int client);
  *
  * @param client		Index of client.
  * @param credits		Amount of credits.
- * @param reason		Optional reason for changed credits.
  * 
  * @noreturn
  */

--- a/addons/sourcemod/scripting/store/natives.sp
+++ b/addons/sourcemod/scripting/store/natives.sp
@@ -185,7 +185,7 @@ public int Native_SetClientCredits(Handle plugin,int numParams)
 	int client = GetNativeCell(1);
 	int m_iCredits = GetNativeCell(2);
 	Store_LogMessage(client, m_iCredits-g_eClients[client].iCredits, "Set by external plugin");
-	g_eClients[client].iCredits = g_eClients[client].iCredits + m_iCredits < 0 ? 0 : m_iCredits;
+	g_eClients[client].iCredits = m_iCredits < 0 ? 0 : m_iCredits;
 	Store_SaveClientData(client);
 	return 1;
 }

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -1025,7 +1025,7 @@ public int Native_SetClientCredits(Handle plugin,int numParams)
 	int client = GetNativeCell(1);
 	int m_iCredits = GetNativeCell(2);
 	Store_LogMessage(client, m_iCredits-g_eClients[client].iCredits, "Set by external plugin");
-	g_eClients[client].iCredits = g_eClients[client].iCredits + m_iCredits < 0 ? 0 : m_iCredits;
+	g_eClients[client].iCredits = m_iCredits < 0 ? 0 : m_iCredits;
 	Store_SaveClientData(client);
 	return 1;
 }


### PR DESCRIPTION
This PR fixes problems with Native_SetClientCredits, namely a check that was added to prevent clients from having a negative amount of credits, but that acted like a GiveCredits check, instead of a SetCredits check.
Here, we set the amount of credits to a fixed number, rather than adding credits to the player count, so the previous check made no sense.

❌ Didn't try to compile
❌ Not tested in game