### PR TITLE
Fixed load queries going through map changes

### DIFF
--- a/addons/sourcemod/scripting/store/sql.sp
+++ b/addons/sourcemod/scripting/store/sql.sp
@@ -170,7 +170,7 @@ public void SQLCallback_LoadClientInventory_Credits(Handle owner, Handle hndl, c
 	else
 	{
 		int client = GetClientOfUserId(userid);
-		if(!client)
+		if (!client || !IsClientInGame(client))
 			return;
 		
 		char m_szQuery[256];
@@ -226,7 +226,7 @@ public void SQLCallback_LoadClientInventory_Items(Handle owner, Handle hndl, con
 	else
 	{	
 		int client = GetClientOfUserId(userid);
-		if(!client)
+		if (!client || !IsClientInGame(client))
 			return;
 
 		char m_szQuery[256];
@@ -280,7 +280,7 @@ public void SQLCallback_LoadClientInventory_Equipment(Handle owner, Handle hndl,
 	else
 	{
 		int client = GetClientOfUserId(userid);
-		if(!client)
+		if (!client || !IsClientInGame(client))
 			return;
 		
 		char m_szUniqueId[PLATFORM_MAX_PATH];

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -4063,7 +4063,10 @@ public void Store_SellItem(int client,int itemid)
 
 	g_eClients[client].iCredits += m_iCredits;
 	//Chat(client, "%t", "Chat Sold Item", g_eItems[itemid].szName, g_eTypeHandlers[g_eItems[itemid].iHandler].szType);
-	CPrintToChat(client, "%s%t", g_sChatPrefix, "Chat Sold Item", g_eItems[itemid].szName, g_eTypeHandlers[g_eItems[itemid].iHandler].szType);
+	if (IsClientInGame(client)) // Prevents a rare error case where a restricted item would be auto-sold during a map change
+	{
+		CPrintToChat(client, "%s%t", g_sChatPrefix, "Chat Sold Item", g_eItems[itemid].szName, g_eTypeHandlers[g_eItems[itemid].iHandler].szType);
+	}
 	
 	Store_UnequipItem(client, itemid);
 	

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -3574,7 +3574,7 @@ public void SQLCallback_LoadClientInventory_Credits(Handle owner, Handle hndl, c
 	else
 	{
 		int client = GetClientOfUserId(userid);
-		if(!client)
+		if (!client || !IsClientInGame(client))
 			return;
 		
 		char m_szQuery[256];
@@ -3630,7 +3630,7 @@ public void SQLCallback_LoadClientInventory_Items(Handle owner, Handle hndl, con
 	else
 	{	
 		int client = GetClientOfUserId(userid);
-		if(!client)
+		if (!client || !IsClientInGame(client))
 			return;
 
 		char m_szQuery[256];
@@ -3684,7 +3684,7 @@ public void SQLCallback_LoadClientInventory_Equipment(Handle owner, Handle hndl,
 	else
 	{
 		int client = GetClientOfUserId(userid);
-		if(!client)
+		if (!client || !IsClientInGame(client))
 			return;
 		
 		char m_szUniqueId[PLATFORM_MAX_PATH];
@@ -4063,10 +4063,7 @@ public void Store_SellItem(int client,int itemid)
 
 	g_eClients[client].iCredits += m_iCredits;
 	//Chat(client, "%t", "Chat Sold Item", g_eItems[itemid].szName, g_eTypeHandlers[g_eItems[itemid].iHandler].szType);
-	if (IsClientInGame(client)) // Prevents a rare error case where a restricted item would be auto-sold during a map change
-	{
-		CPrintToChat(client, "%s%t", g_sChatPrefix, "Chat Sold Item", g_eItems[itemid].szName, g_eTypeHandlers[g_eItems[itemid].iHandler].szType);
-	}
+	CPrintToChat(client, "%s%t", g_sChatPrefix, "Chat Sold Item", g_eItems[itemid].szName, g_eTypeHandlers[g_eItems[itemid].iHandler].szType);
 	
 	Store_UnequipItem(client, itemid);
 	


### PR DESCRIPTION
This PR fixes an error I ran into with the new auto-sell restricted items feature.

```cpp
L 12/20/2022 - 17:12:11: [SM] Exception reported: Client 2 is not in game
L 12/20/2022 - 17:12:11: [SM] Blaming: store.smx
L 12/20/2022 - 17:12:11: [SM] Call stack trace:
L 12/20/2022 - 17:12:11: [SM]   [0] ThrowError
L 12/20/2022 - 17:12:11: [SM]   [1] Line 71, colorvariables::CPrintToChat
L 12/20/2022 - 17:12:11: [SM]   [2] Line 305, store\store_functions.sp::Store_SellItem
L 12/20/2022 - 17:12:11: [SM]   [3] Line 309, store\sql.sp::SQLCallback_LoadClientInventory_Equipment
```

It happens if a map change occurs right after a player with expired items connect.
This should be fixed by preventing load queries from going through map changes. Shouldn't cause any more problems, since a new load query will be sent after the player fully loads again.

Why did they went through? Well, it's a pretty special case, but when a map change occurs, `OnClientDisconnect()` gets called, but the player's userid doesn't actually change! The client will quickly disconnect and reconnect, but will keep its old userid. It'll still resolve to a client index, but a different one.
TL;DR, when a map change occurs, a player's client index gets changed but not their userid. It is therefore needed to check `IsClientInGame()` if we're going to use permission-related functions or functions that require that a player is in game.

❌ Didn't try to compile
❌ Not tested in game