### PR TITLE
Fixed item expiration SQL queries

### DIFF
--- a/addons/sourcemod/scripting/store/db.sp
+++ b/addons/sourcemod/scripting/store/db.sp
@@ -38,10 +38,15 @@ public void Store_DB_HouseKeeping(Handle db)
 {
 	// Do some housekeeping
 	char m_szQuery[256], m_szLogCleaningQuery[256];
-	Format(STRING(m_szQuery), "delete `store_items`, `store_equipment`"
-							... "from  `store_items`, `store_equipment` "
-							... "where (store_items.unique_id = store_equipment.unique_id) "
-							... "and store_items.date_of_expiration<>0 and store_items.date_of_expiration<%d", GetTime());
+	// Remove expired and equipped items
+	Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
+							... "WHERE (store_items.unique_id = store_equipment.unique_id) "
+								... "AND store_items.date_of_expiration != 0 "
+								... "AND store_items.date_of_expiration < %d", GetTime());
+	SQL_TVoid(db, m_szQuery);
+	
+	// Remove expired and unequipped items
+	Format(STRING(m_szQuery), "DELETE FROM store_items WHERE date_of_expiration != 0 AND date_of_expiration < %d", GetTime());
 	SQL_TVoid(db, m_szQuery);
 	
 	char m_szDriver[2];

--- a/addons/sourcemod/scripting/store/sql.sp
+++ b/addons/sourcemod/scripting/store/sql.sp
@@ -131,7 +131,15 @@ public void SQLCallback_Connect(Handle owner, Handle hndl, const char[] error, a
 		
 		// Do some housekeeping
 		char m_szQuery[256], m_szLogCleaningQuery[256];
-		Format(STRING(m_szQuery), "DELETE FROM store_items WHERE `date_of_expiration` <> 0 AND `date_of_expiration` < %d", GetTime());
+		// Remove expired and equipped items
+		Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
+								... "WHERE (store_items.unique_id = store_equipment.unique_id) "
+									... "AND store_items.date_of_expiration != 0 "
+									... "AND store_items.date_of_expiration < %d", GetTime());
+		SQL_TVoid(g_hDatabase, m_szQuery);
+		
+		// Remove expired and unequipped items
+		Format(STRING(m_szQuery), "DELETE FROM store_items WHERE date_of_expiration != 0 AND date_of_expiration < %d", GetTime());
 		SQL_TVoid(g_hDatabase, m_szQuery);
 		
 

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -826,10 +826,15 @@ public void OnConfigsExecuted()
 	else
 	{
 		char m_szQuery[256], m_szLogCleaningQuery[256];
-		Format(STRING(m_szQuery), "delete `store_items`, `store_equipment`"
-								... "from  `store_items`, `store_equipment` "
-								... "where (store_items.unique_id = store_equipment.unique_id) "
-								... "and store_items.date_of_expiration<>0 and store_items.date_of_expiration<%d", GetTime());
+		// Remove expired and equipped items
+		Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
+								... "WHERE (store_items.unique_id = store_equipment.unique_id) "
+									... "AND store_items.date_of_expiration != 0 "
+									... "AND store_items.date_of_expiration < %d", GetTime());
+		SQL_TVoid(g_hDatabase, m_szQuery);
+		
+		// Remove expired and unequipped items
+		Format(STRING(m_szQuery), "DELETE FROM store_items WHERE date_of_expiration != 0 AND date_of_expiration < %d", GetTime());
 		SQL_TVoid(g_hDatabase, m_szQuery);
 		
 		char m_szDriver[2];
@@ -3552,7 +3557,15 @@ public void SQLCallback_Connect(Handle owner, Handle hndl, const char[] error, a
 		
 		// Do some housekeeping
 		char m_szQuery[256], m_szLogCleaningQuery[256];
-		Format(STRING(m_szQuery), "DELETE FROM store_items WHERE `date_of_expiration` <> 0 AND `date_of_expiration` < %d", GetTime());
+		// Remove expired and equipped items
+		Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
+								... "WHERE (store_items.unique_id = store_equipment.unique_id) "
+									... "AND store_items.date_of_expiration != 0 "
+									... "AND store_items.date_of_expiration < %d", GetTime());
+		SQL_TVoid(g_hDatabase, m_szQuery);
+		
+		// Remove expired and unequipped items
+		Format(STRING(m_szQuery), "DELETE FROM store_items WHERE date_of_expiration != 0 AND date_of_expiration < %d", GetTime());
 		SQL_TVoid(g_hDatabase, m_szQuery);
 		
 		/*Format(STRING(m_szVoucherQuery), "UPDATE store_voucher SET"


### PR DESCRIPTION
Thanks to #146 for reporting an SQL error

This patch fixes the following error:
```
[store.smx] SQL error happened.
Query: delete `store_items`, `store_equipment`from `store_items`, `store_equipment` where (store_items.unique_id = store_equipment.unique_id) and store_items.date_of_expiration<>0 and store_items.date_of_expiration<1676067429
Error: near "store_items": syntax error
```

It should also fix items not properly expiring as:
- On initial DB connection, only unequipped expired items where deleted
- On future map changes, only equipped expired items where deleted

In both cases, it should now delete **both** equipped and unequipped expired items

**Please note that my work might need more optimization. We could use a function to clear the DB since code is reused in 2 different locations.**

❌ Didn't try to compile
❌ Didn't test in game