### PR TITLE
Made commands customizable

### DIFF
--- a/addons/sourcemod/scripting/include/zephstocks.inc
+++ b/addons/sourcemod/scripting/include/zephstocks.inc
@@ -22,7 +22,7 @@
 #endif
 
 #define MSG_LENGTH 192
-#define CVAR_LENGTH 128
+#define CVAR_LENGTH 256
 
 #define MAX_CVARS 128
 

--- a/addons/sourcemod/scripting/store.sp
+++ b/addons/sourcemod/scripting/store.sp
@@ -345,6 +345,15 @@ public void OnMapEnd()
 
 public void OnConfigsExecuted()
 {
+	static bool bFirstLoad = true; // See https://wiki.alliedmods.net/Introduction_to_SourcePawn_1.7#Local_static
+	
+	if (bFirstLoad)
+	{
+		bFirstLoad = false;
+		
+		Store_Commands_OnConfigsExecuted(); // store/commands.sp
+	}
+	
 	//Jetpack_OnConfigsExecuted();
 	//Jihad_OnConfigsExecuted();
 	

--- a/addons/sourcemod/scripting/store/commands.sp
+++ b/addons/sourcemod/scripting/store/commands.sp
@@ -1,15 +1,7 @@
 void Store_Commands_OnPluginStart()
 {
 	// Register Commands
-	RegConsoleCmd("sm_store", Command_Store);
-	RegConsoleCmd("sm_shop", Command_Store);
-	RegConsoleCmd("sm_inv", Command_Inventory);
-	RegConsoleCmd("sm_inventory", Command_Inventory);
-	RegConsoleCmd("sm_gift", Command_Gift);
-	RegConsoleCmd("sm_givecredits", Command_GiveCredits);
-	RegConsoleCmd("sm_resetplayer", Command_ResetPlayer);
-	RegConsoleCmd("sm_rsloadout", Command_ResetLoadout);
-	RegConsoleCmd("sm_credits", Command_Credits);
+	// --- Other commands are now registered in OnConfigsExecuted with the RegisterCommand function ---
 	RegServerCmd("sm_store_custom_credits", Command_CustomCredits);
 	
 	RegAdminCmd("sm_store_reloadconfig", Command_ReloadConfig, ADMFLAG_ROOT);
@@ -17,6 +9,38 @@ void Store_Commands_OnPluginStart()
 	// Add a say command listener for shortcuts
 	AddCommandListener(Command_Say, "say");
 	AddCommandListener(Command_Say, "say_team");
+}
+
+void Store_Commands_OnConfigsExecuted()
+{	
+	// Register commands
+	char sCommands[10][60]; // 10 commands of 60 bytes max
+	RegisterCommand(g_eCvars[g_cvarCommandsStore].sCache, Command_Store, sCommands, sizeof(sCommands), sizeof(sCommands[]));
+	RegisterCommand(g_eCvars[g_cvarCommandsInventory].sCache, Command_Inventory, sCommands, sizeof(sCommands), sizeof(sCommands[]));
+	RegisterCommand(g_eCvars[g_cvarCommandsGift].sCache, Command_Gift, sCommands, sizeof(sCommands), sizeof(sCommands[]));
+	RegisterCommand(g_eCvars[g_cvarCommandsGive].sCache, Command_GiveCredits, sCommands, sizeof(sCommands), sizeof(sCommands[]));
+	RegisterCommand(g_eCvars[g_cvarCommandsResetPlayer].sCache, Command_ResetPlayer, sCommands, sizeof(sCommands), sizeof(sCommands[]));
+	RegisterCommand(g_eCvars[g_cvarCommandsCredits].sCache, Command_Credits, sCommands, sizeof(sCommands), sizeof(sCommands[]));
+	RegisterCommand(g_eCvars[g_cvarCommandsResetLoadout].sCache, Command_ResetLoadout, sCommands, sizeof(sCommands), sizeof(sCommands[]));
+}
+
+/**
+ * Registers one or multiple commands that point towards the same callback.
+ * Designed to be used once in OnConfigsExecuted, to allow customizable commands.
+ * -
+ * const char[] command		A string containing the commands, starting with the sm_ prefix, and two commands being separated by a comma (,).
+ * Function callback		The command callback: the function that will be called when the command is executed.
+ * char[][] sCommands		A 2D string array. First dimension: max number of commands, second dimension: max command size.
+ * int sCommandsSize		sizeof(sCommands)
+ * int sCommandsSize2		sizeof(sCommands[])
+ */
+stock void RegisterCommand(const char[] command, Function callback, char[][] sCommands, int sCommandsSize, int sCommandsSize2)
+{
+	int iCommands = ExplodeString(g_eCvars[g_cvarCommandsStore].sCache, ",", sCommands, sCommandsSize, sCommandsSize2);
+	for (int i; i < iCommands; i++)
+	{
+		RegConsoleCmd(sCommands[i], callback);
+	}
 }
 
 //////////////////////////////////

--- a/addons/sourcemod/scripting/store/cvars.sp
+++ b/addons/sourcemod/scripting/store/cvars.sp
@@ -31,6 +31,13 @@ int gc_iDescription = -1;
 int gc_iReloadType = -1;
 int gc_iReloadDelay = -1;
 int gc_iReloadNotify = -1;
+int g_cvarCommandsStore = -1;
+int g_cvarCommandsInventory = -1;
+int g_cvarCommandsGift = -1;
+int g_cvarCommandsGive = -1;
+int g_cvarCommandsResetPlayer = -1;
+int g_cvarCommandsCredits = -1;
+int g_cvarCommandsResetLoadout = -1;
 ConVar g_cvarGiveItemBehavior;
 ConVar g_cvarChatTag;
 
@@ -85,7 +92,14 @@ void Store_Cvars_OnPluginStart()
 	gc_iReloadDelay = RegisterConVar("sm_store_reload_config_delay", "10", "Time in second to reload current map on store reload config. Dependence: \"sm_store_reload_config_type\" 0", TYPE_INT);
 	gc_iReloadNotify = RegisterConVar("sm_store_reload_config_notify", "1", "Store reloadconfig notify player", TYPE_INT);
 
-	
+	g_cvarCommandsStore = RegisterConVar("sm_store_commands_store", "sm_store,sm_shop", "A list of commands that can be used to open the store. Two commands must be separated by a comma (,). Max 10 commands.", TYPE_STRING);
+	g_cvarCommandsInventory = RegisterConVar("sm_store_commands_inventory", "sm_inventory,sm_inv", "A list of commands that can be used to open the inventory. Two commands must be separated by a comma (,). Max 10 commands.", TYPE_STRING);
+	g_cvarCommandsGift = RegisterConVar("sm_store_commands_gift", "sm_gift", "A list of commands that can be used to gift credits. Two commands must be separated by a comma (,). Max 10 commands.", TYPE_STRING);
+	g_cvarCommandsGive = RegisterConVar("sm_store_commands_give", "sm_givecredits", "A list of commands that can be used to give credits (as an ADMIN). Two commands must be separated by a comma (,). Max 10 commands.", TYPE_STRING);
+	g_cvarCommandsResetPlayer = RegisterConVar("sm_store_commands_resetplayer", "sm_resetplayer,sm_store_resetplayer", "A list of commands that can be used to reset a player's data (as an ADMIN). Two commands must be separated by a comma (,). Max 10 commands.", TYPE_STRING);
+	g_cvarCommandsCredits = RegisterConVar("sm_store_commands_credits", "sm_credits", "A list of commands that can be used to display the amount of credits you have. Two commands must be separated by a comma (,). Max 10 commands.", TYPE_STRING);
+	g_cvarCommandsResetLoadout = RegisterConVar("sm_store_commands_resetloadout", "sm_rsloadout,sm_resetloadout,sm_store_rsloadout,sm_store_resetloadout", "A list of commands that can be used to unequip all the equipped items you have. Two commands must be separated by a comma (,). Max 10 commands.", TYPE_STRING);
+
 	g_cvarChatTag.AddChangeHook(OnSettingChanged);
 	
 	// After every module was loaded we are ready to generate the cfg


### PR DESCRIPTION
This PR makes commands customizable through cvars.
Not sure if not updating the .cfg file could be a problem, or if the plugin would just use the default values in this case.

Up to 10 commands are allowed for each command callback (store, inventory...), each command having a maximum length of 60 bytes. Feel free to modify that if you want to.

The zephstocks.inc's cvar value max string size was doubled (128 -> 256) in order to allow more commands.

This change could break plugins that try to run store commands through the console (with `ServerCommand()`) before configs are loaded, and on the initial load. It is a very specific case, but I guess it could happen, so I'm warning anyway.

**This PR implies big changes and should be heavily tested before it is accepted as it could break other things, and render the plugin unusable (if bugged).**

❌ Didn't try to compile
❌ Didn't test in game