### PR TITLE
Fix SQL Queries

### DIFF
--- a/addons/sourcemod/scripting/store/db.sp
+++ b/addons/sourcemod/scripting/store/db.sp
@@ -39,8 +39,8 @@ public void Store_DB_HouseKeeping(Handle db)
 	// Do some housekeeping
 	char m_szQuery[256], m_szLogCleaningQuery[256];
 	// Remove expired and equipped items
-	Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
-							... "WHERE (store_items.unique_id = store_equipment.unique_id) "
+	Format(STRING(m_szQuery), "DELETE store_items, store_equipment FROM store_items, store_equipment "
+							... "WHERE store_items.unique_id = store_equipment.unique_id "
 								... "AND store_items.date_of_expiration != 0 "
 								... "AND store_items.date_of_expiration < %d", GetTime());
 	SQL_TVoid(db, m_szQuery);

--- a/addons/sourcemod/scripting/store/sql.sp
+++ b/addons/sourcemod/scripting/store/sql.sp
@@ -132,8 +132,8 @@ public void SQLCallback_Connect(Handle owner, Handle hndl, const char[] error, a
 		// Do some housekeeping
 		char m_szQuery[256], m_szLogCleaningQuery[256];
 		// Remove expired and equipped items
-		Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
-								... "WHERE (store_items.unique_id = store_equipment.unique_id) "
+		Format(STRING(m_szQuery), "DELETE store_items, store_equipment FROM store_items, store_equipment "
+								... "WHERE store_items.unique_id = store_equipment.unique_id "
 									... "AND store_items.date_of_expiration != 0 "
 									... "AND store_items.date_of_expiration < %d", GetTime());
 		SQL_TVoid(g_hDatabase, m_szQuery);

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -827,8 +827,8 @@ public void OnConfigsExecuted()
 	{
 		char m_szQuery[256], m_szLogCleaningQuery[256];
 		// Remove expired and equipped items
-		Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
-								... "WHERE (store_items.unique_id = store_equipment.unique_id) "
+		Format(STRING(m_szQuery), "DELETE store_items, store_equipment FROM store_items, store_equipment "
+								... "WHERE store_items.unique_id = store_equipment.unique_id "
 									... "AND store_items.date_of_expiration != 0 "
 									... "AND store_items.date_of_expiration < %d", GetTime());
 		SQL_TVoid(g_hDatabase, m_szQuery);


### PR DESCRIPTION
on map load, the plugin was giving a sql error, like this (ON THE LAST VERSION OF PLUGIN):

Sourcemod version: 1.11.6932

```
[store.smx] SQL error happened.
Query: DELETE FROM store_items, store_equipment WHERE (store_items.unique_id = store_equipment.unique_id) AND store_items.date_of_expiration != 0 AND store_items.date_of_expiration < 1681787415

#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'WHERE (store_items.unique_id = store_equipment.unique_id) AND store_items.date_o' at line 1
```

i changed the code and made a quick test, seems to work good!