### PR TITLE
Fixed item expiration SQL queries, part 2

### DIFF
--- a/addons/sourcemod/scripting/store/sql.sp
+++ b/addons/sourcemod/scripting/store/sql.sp
@@ -130,34 +130,7 @@ public void SQLCallback_Connect(Handle owner, Handle hndl, const char[] error, a
 		}
 		
 		// Do some housekeeping
-		char m_szQuery[256], m_szLogCleaningQuery[256];
-		// Remove expired and equipped items
-		Format(STRING(m_szQuery), "DELETE FROM store_items, store_equipment "
-								... "WHERE (store_items.unique_id = store_equipment.unique_id) "
-									... "AND store_items.date_of_expiration != 0 "
-									... "AND store_items.date_of_expiration < %d", GetTime());
-		SQL_TVoid(g_hDatabase, m_szQuery);
-		
-		// Remove expired and unequipped items
-		Format(STRING(m_szQuery), "DELETE FROM store_items WHERE date_of_expiration != 0 AND date_of_expiration < %d", GetTime());
-		SQL_TVoid(g_hDatabase, m_szQuery);
-		
-
-		if (g_eCvars[g_cvarLogLast].aCache>0)
-		{
-			if(m_szDriver[0] == 'm')
-			{
-				Format(STRING(m_szLogCleaningQuery), "DELETE FROM store_plugin_logs WHERE `date` < CURDATE()-%i", g_eCvars[g_cvarLogLast].aCache);
-				SQL_TVoid(g_hDatabase, m_szLogCleaningQuery);
-				Format(STRING(m_szLogCleaningQuery), "DELETE FROM store_logs WHERE `date` < CURDATE()-%i", g_eCvars[g_cvarLogLast].aCache);
-				SQL_TVoid(g_hDatabase, m_szLogCleaningQuery);
-			}
-			else
-			{
-				Format(STRING(m_szLogCleaningQuery), "DELETE FROM store_plugin_logs WHERE `date` < (SELECT DATETIME('now', '-%i day'))", g_eCvars[g_cvarLogLast].aCache);
-				SQL_TVoid(g_hDatabase, m_szLogCleaningQuery);
-			}
-		}
+		Store_DB_HouseKeeping(g_hDatabase);
 		
 		if(!SQL_SetCharset(g_hDatabase, "utf8mb4")){
 			SQL_SetCharset(g_hDatabase, "utf8");


### PR DESCRIPTION
I previously broke item expiration SQL queries for MySQL, and fixed it for SQLite (see #147), due to me being dumb and not knowing the MySQL syntax (or MySQL not being powerful enough :D).

Thanks to @cleber1337 - @strteamservidores for reporting this issue and making a PR (#160) that essentially reverted my changes 😆

This should fix the problem for both MySQL and SQLite drivers. Sorry PostgreSQL, no one likes you.

This should also improve the code a bit (by removing the duplicate DB_HouseKeeping code). Let's hope nothing breaks this time!

❌ Didn't try to compile
❌ Didn't test in game