### PR TITLE
Fixed store chat tag bug

### DIFF
--- a/addons/sourcemod/scripting/store.sp
+++ b/addons/sourcemod/scripting/store.sp
@@ -348,6 +348,8 @@ public void OnConfigsExecuted()
 	//Jetpack_OnConfigsExecuted();
 	//Jihad_OnConfigsExecuted();
 	
+	Store_Cvars_OnConfigsExecuted(); // store/cvars.sp
+	
 	// Call foward Store_OnConfigsExecuted
 	Store_Forward_OnConfigsExecuted(); // store/configs.sp
 

--- a/addons/sourcemod/scripting/store/cvars.sp
+++ b/addons/sourcemod/scripting/store/cvars.sp
@@ -102,6 +102,12 @@ public void OnSettingChanged(ConVar convar, const char[] oldValue, const char[] 
 	}
 }
 
+void Store_Cvars_OnConfigsExecuted()
+{
+	// Needed, because OnSettingChanged isn't called on config execution if the cvar has the default value (as there is no change in the cvar's value)
+	g_cvarChatTag.GetString(g_sChatPrefix, sizeof(g_sChatPrefix));
+}
+
 //////////////////////////////
 //			CONVARS	 		//
 //////////////////////////////

--- a/addons/sourcemod/scripting/store_combine.sp
+++ b/addons/sourcemod/scripting/store_combine.sp
@@ -814,6 +814,8 @@ public void OnConfigsExecuted()
 	//Jetpack_OnConfigsExecuted();
 	//Jihad_OnConfigsExecuted();
 	
+	Store_Cvars_OnConfigsExecuted();
+	
 	// Call foward Store_OnConfigsExecuted
 	Forward_OnConfigsExecuted();
 
@@ -4704,4 +4706,10 @@ void Store_DB_HouseKeeping(Handle db)
 			SQL_TVoid(db, m_szLogCleaningQuery);
 		}
 	}
+}
+
+void Store_Cvars_OnConfigsExecuted()
+{
+	// Needed, because OnSettingChanged isn't called on config execution if the cvar has the default value (as there is no change in the cvar's value)
+	g_cvarChatTag.GetString(g_sChatPrefix, sizeof(g_sChatPrefix));
 }


### PR DESCRIPTION
Fixes #162

Currently, the plugin's chat tag is cached in a variable `g_sChatPrefix`. This variable gets updated when the convar linked to it is modified, but the ChangeHook event `OnSettingChanged` is not called if it is the same as the default value.

In short, if the default value for the cvar is used, `g_sChatPrefix` is never updated, and stays an empty string.
This PR fixes that by reading from the cvar's value in `OnConfigsExecuted`.

❌ Didn't try to compile
❌ Not tested in game